### PR TITLE
return the original stream if no replacements are passed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,13 @@ workflows:
   build:
     jobs:
       - test:
+          name: 10-stretch
           version: 10-stretch
       - test:
+          name: lts-stretch
           version: lts-stretch
       - test:
+          name: current-stretch
           version: current-stretch
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run: npm ci
       - run: npm t
       - run: |
-          if [ "$CIRCLE_BRANCH" == "master" ] && [ "$CIRCLE_STAGE" == "test-3" ] && [ "$CIRCLE_USERNAME" != "wpcomvip-bot" ]; then
+          if [ "$CIRCLE_BRANCH" == "master" ] && [ "$CIRCLE_STAGE" == "lts-stretch" ] && [ "$CIRCLE_USERNAME" != "wpcomvip-bot" ]; then
                 echo "Running nlm release";
                 npx nlm release;
           else

--- a/__tests__/lib/index.test.js
+++ b/__tests__/lib/index.test.js
@@ -1,11 +1,14 @@
 const thisPackage = require( '../../' );
 const { replace, validate } = thisPackage;
 const fs = require( 'fs' );
+const path = require( 'path' );
 const { expect } = require( '@jest/globals' );
 
+const processPath = process.cwd();
+
 let readableStream, writeableStream;
-const readFilePath = __dirname + '/in-sample.sql';
-const writeFilePath = __dirname + '/out-sample.sql';
+const readFilePath = path.join( processPath, '__tests__', 'lib', 'in-sample.sql' );
+const writeFilePath = path.join( processPath, '__tests__', 'lib', 'out-sample.sql' );
 
 beforeEach( () => {
 	readableStream = fs.createReadStream( readFilePath );
@@ -16,7 +19,7 @@ afterEach( () => {
 	readableStream.close();
 	writeableStream.close();
 	fs.unlinkSync( writeFilePath );
-	fs.truncateSync( process.cwd() + '/bin/go-search-replace' );
+	fs.truncateSync( path.join( processPath, 'bin', 'go-search-replace' ) );
 } );
 
 async function testHarness( replacements ) {

--- a/__tests__/lib/index.test.js
+++ b/__tests__/lib/index.test.js
@@ -18,7 +18,9 @@ beforeEach( () => {
 afterEach( () => {
 	readableStream.close();
 	writeableStream.close();
-	fs.unlinkSync( writeFilePath );
+	if ( fs.existsSync( writeFilePath ) ) {
+		fs.unlinkSync( writeFilePath );
+	}
 	fs.truncateSync( path.join( processPath, 'bin', 'go-search-replace' ) );
 } );
 

--- a/__tests__/lib/index.test.js
+++ b/__tests__/lib/index.test.js
@@ -60,12 +60,14 @@ describe( 'go-search-replace', () => {
 		it( 'returns an instance of the stdout object', async () => {
 			const { outFile } = await testHarness( [ 'thisdomain.com', 'thatdomain.com' ] );
 			expect( outFile ).toContain( 'thatdomain.com' );
+			expect( outFile ).not.toContain( 'thisdomain.com' );
 		} );
 
 		it( 'returns the original stream if no replacements are in the array', async () => {
 			const { result, outFile } = await testHarness( [] );
 			expect( result ).toEqual( readableStream );
 			expect( outFile ).toContain( 'thisdomain.com' );
+			expect( outFile ).not.toContain( 'thatdomain.com' );
 		} );
 	} );
 } );

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ async function replace( streamObj, replacements, binary = null ) {
 	debug( 'The supplied arguments are valid' );
 
 	if ( ! replacements.length ) {
-		console.log( 'No replacements were provided to search and replace with.' );
+		debug( 'No replacements were provided to search and replace with.' );
 		return streamObj;
 	}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,6 +68,11 @@ async function replace( streamObj, replacements, binary = null ) {
 	}
 	debug( 'The supplied arguments are valid' );
 
+	if ( ! replacements.length ) {
+		console.log( 'No replacements were provided to search and replace with.' );
+		return streamObj;
+	}
+
 	// only download the binary if we didn't supply one
 	if ( binary === null ) {
 		try {


### PR DESCRIPTION
While working on adding this package to another library, I realized it's beneficial to the flow of the code to return the original stream if no replacements are provided.  This PR aims to keep that logic in this library instead of in the consumers of it.

Steps to test:

1. Pull down this PR
1. `npm t`

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.1.0)_