### PR TITLE
fix: Incorrect path is used for downloaded binary

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,10 +73,13 @@ async function replace( streamObj, replacements, binary = null ) {
 		return streamObj;
 	}
 
+	let useBinary = binary || 'go-search-replace';
+
 	// only download the binary if we didn't supply one
 	if ( binary === null ) {
 		try {
 			const downloaded = await downloadBinary();
+			useBinary = downloaded.path;
 			debug( downloaded );
 		} catch ( err ) {
 			console.error( err );
@@ -86,8 +89,6 @@ async function replace( streamObj, replacements, binary = null ) {
 	}
 
 	debug( 'Go binaries are installed' );
-
-	const useBinary = binary || 'go-search-replace';
 
 	const replaceProcess = spawn( useBinary, replacements, {
 		stdio: [ 'pipe', 'pipe', process.stderr ],

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -66,20 +66,19 @@ const downloadBinary = ( currentUrl, writePath = null ) => {
 
 			if ( res.statusCode >= 300 && res.statusCode < 400 ) {
 				debug( 'Redirecting to:', res.headers.location );
-				await downloadBinary( res.headers.location, writePath );
-				resolve();
-			} else {
-				const writeTo = writePath || binPath;
-				const writeStream = fs.createWriteStream( writeTo, { mode: 0o755 } );
-				writeStream.on( 'error', writeErr => {
-					console.error( writeErr );
-					reject( writeErr );
-				} );
-				writeStream.on( 'finish', () => {
-					resolve( 'done' );
-				} );
-				res.pipe( gunzip ).pipe( writeStream );
+				return resolve( await downloadBinary( res.headers.location, writePath ) );
 			}
+
+			const writeTo = writePath || binPath;
+			const writeStream = fs.createWriteStream( writeTo, { mode: 0o755 } );
+			writeStream.on( 'error', writeErr => {
+				console.error( writeErr );
+				reject( writeErr );
+			} );
+			writeStream.on( 'finish', () => {
+				resolve( { path: writeTo } );
+			} );
+			res.pipe( gunzip ).pipe( writeStream );
 		} )
 			.on( 'error', err => {
 				debug( 'ERROR:', err );


### PR DESCRIPTION
As is, we're using the `go-search-replace` executable that's in your $PATH when not specifying a binary by virtue of this line:
https://github.com/Automattic/vip-search-replace/blob/1362c08e250da1b1b8ff320026e4a89f7f808444/lib/index.js#L90

This change makes `downloadBinary` supply the path (so it can leverage its support for specifying the `writePath`.  Then, `replace` uses the `path` that is provided as a fallback when no binary is provided by the caller.

Discussion: p1606843944345500-slack-CKUJZT08Y

## To Test

* Automated tests should pass
* Check out the CLI branch adding support for search / replace: https://github.com/Automattic/vip/pull/605
* In the `vip` CLI directory, install this version of the package: `npm i "git+https://github.com/Automattic/vip-search-replace.git#cd3232d"`
* Follow the test plan in the other PR