### PR TITLE
perf: Download using the 'latest release' redirect URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,7 @@ async function replace( streamObj, replacements, binary = null ) {
 		try {
 			const downloaded = await downloadBinary();
 			useBinary = downloaded.path;
-			debug( downloaded );
+			debug( `Using binary at path: ${ useBinary }` );
 		} catch ( err ) {
 			console.error( err );
 		}

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-const https = require( 'https' );
+const { https } = require( 'follow-redirects' );
 const gunzip = require( 'zlib' ).createGunzip();
 const fs = require( 'fs' );
 const path = require( 'path' );
@@ -33,9 +33,6 @@ debug( binPath );
 if ( ! fs.existsSync( path.dirname( binPath ) ) ) {
 	fs.mkdirSync( path.dirname( binPath ) );
 }
-
-// Config
-const URL = 'https://github.com/Automattic/go-search-replace/releases/download/{{version}}/go-search-replace_{{platform}}_{{arch}}.gz';
 
 // Mapping from Node's `process.arch` to Golang's `$GOARCH`
 const ARCH_MAPPING = {
@@ -52,23 +49,20 @@ const PLATFORM_MAPPING = {
 	freebsd: 'freebsd',
 };
 
-// Windows executables compiled by Golang have a `.exe` extension
-let arch = ARCH_MAPPING[ process.arch ];
-if ( process.platform === 'win32' ) {
-	arch += '.exe';
+function getLatestReleaseUrlForPlatformAndArch() {
+	// Windows executables compiled by Golang have a `.exe` extension
+	const arch = `${ ARCH_MAPPING[ process.arch ] }${ process.platform === 'win32' ? '.exe' : '' }`;
+
+	return 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_{{platform}}_{{arch}}.gz'
+		.replace( /{{arch}}/, arch )
+		.replace( /{{platform}}/, PLATFORM_MAPPING[ process.platform ] );
 }
 
-const downloadBinary = ( currentUrl, writePath = null ) => {
+const downloadBinary = ( url = getLatestReleaseUrlForPlatformAndArch(), writePath = null ) => {
 	return new Promise( ( resolve, reject ) => {
-		debug( 'Current URL: ', currentUrl );
-		https.request( currentUrl, async res => {
-			debug( 'StatusCode: ', res.statusCode );
-
-			if ( res.statusCode >= 300 && res.statusCode < 400 ) {
-				debug( 'Redirecting to:', res.headers.location );
-				return resolve( await downloadBinary( res.headers.location, writePath ) );
-			}
-
+		debug( 'Requested URL: ', url );
+		https.request( url, res => {
+			debug( JSON.stringify( { statusCode: res.statusCode, responseUrl: res.responseUrl } ) );
 			const writeTo = writePath || binPath;
 			const writeStream = fs.createWriteStream( writeTo, { mode: 0o755 } );
 			writeStream.on( 'error', writeErr => {
@@ -76,6 +70,7 @@ const downloadBinary = ( currentUrl, writePath = null ) => {
 				reject( writeErr );
 			} );
 			writeStream.on( 'finish', () => {
+				debug( `Downloaded & unpacked binary to path: ${ writeTo }` );
 				resolve( { path: writeTo } );
 			} );
 			res.pipe( gunzip ).pipe( writeStream );
@@ -88,57 +83,4 @@ const downloadBinary = ( currentUrl, writePath = null ) => {
 	} );
 };
 
-const getLatestBinaryVersion = ( url = null ) => {
-	return new Promise( ( resolve, reject ) => {
-		const latestBinaryReleaseUrl = url || 'https://github.com/Automattic/go-search-replace/releases/latest';
-		debug( 'this', latestBinaryReleaseUrl );
-
-		https.request( latestBinaryReleaseUrl, async res => {
-			debug( 'Latest Status Code: ', res.statusCode );
-			if ( res.statusCode < 200 || res.statusCode >= 400 ) {
-				reject( 'Status Code outside of the acceptable range.' );
-			}
-			if ( res.statusCode >= 300 && res.statusCode < 400 ) {
-				debug( 'Redirecting: ', res.headers.location );
-				let version;
-				try {
-					version = await getLatestBinaryVersion( res.headers.location );
-				} catch ( nestErr ) {
-					reject( nestErr );
-				}
-				resolve( version );
-			} else if ( res.statusCode === 200 ) {
-				const latestVersion = latestBinaryReleaseUrl.split( '/' ).pop();
-				resolve( latestVersion );
-			} else {
-				reject();
-			}
-		} )
-			.on( 'error', error => {
-				debug( 'Error making request to GitHub', error );
-				reject( error );
-			} )
-			.end();
-	} );
-};
-
-const download = async () => {
-	let latestBinaryVersion;
-	try {
-		latestBinaryVersion = await getLatestBinaryVersion();
-		debug( 'Latest Binary Version: ', latestBinaryVersion );
-	} catch ( err ) {
-		throw new Error( 'Could not get the latest binary version' );
-	}
-
-	const url = URL
-		.replace( /{{arch}}/, arch )
-		.replace( /{{platform}}/, PLATFORM_MAPPING[ process.platform ] )
-		.replace( /{{version}}/, latestBinaryVersion );
-
-	return await downloadBinary( url );
-};
-
-download.downloadBinary = downloadBinary;
-
-module.exports = download;
+module.exports = downloadBinary;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3363,6 +3363,11 @@
         "write": "^0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "debug": "^4.2.0"
+    "debug": "^4.2.0",
+    "follow-redirects": "^1.13.0"
   }
 }


### PR DESCRIPTION
This leverages the [follow-redirects npm module](https://www.npmjs.com/package/follow-redirects) to avoid having to maintain logic to handle following redirects.

In addition, it leverages the [dedicated URL to redirect to the latest release](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/linking-to-releases) which saves us a handful of round trips and a slew of code.

## To Test

* Automated tests should pass
* Check out the CLI branch adding support for search / replace: https://github.com/Automattic/vip/pull/605
* In the `vip` CLI directory, install this version of the package: `npm i "git+https://github.com/Automattic/vip-search-replace.git#b8b3146"`
* Follow the test plan in the other PR