### PR TITLE
fix: get-test-binary script bad variable

### DIFF
--- a/lib/get-test-binary.js
+++ b/lib/get-test-binary.js
@@ -23,7 +23,7 @@
  */
 const path = require( 'path' );
 
-const { downloadBinary } = require( './install-go-binary' );
+const downloadBinary = require( './install-go-binary' );
 
 // auto execute an async function
 ( async () => {


### PR DESCRIPTION
The script was broken in #8 because the `downloadBinary` is not exported as an object any longer resulting in this error:

```
$ node lib/get-test-binary.js
(node:3157) UnhandledPromiseRejectionWarning: TypeError: downloadBinary is not a function
    at /Users/jeff/Documents/gitRepos/vip-search-replace/lib/get-test-binary.js:42:8
    at Object.<anonymous> (/Users/jeff/Documents/gitRepos/vip-search-replace/lib/get-test-binary.js:43:4)
```

This formats the variable assignment correctly such that the script works again.