### PR TITLE
Listen for a non-zero exit code from the go-search-replace process

### DIFF
--- a/__tests__/lib/index.test.js
+++ b/__tests__/lib/index.test.js
@@ -1,6 +1,7 @@
 const thisPackage = require( '../../' );
 const { replace, validate } = thisPackage;
 const fs = require( 'fs' );
+const os = require( 'os' );
 const path = require( 'path' );
 const { expect } = require( '@jest/globals' );
 const debug = require( 'debug' )( 'vip-search-replace:index.test' );
@@ -8,8 +9,9 @@ const debug = require( 'debug' )( 'vip-search-replace:index.test' );
 const processPath = process.cwd();
 
 let readableStream, writeableStream;
+const tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), 'vip-search-replace-tests-' ) );
 const readFilePath = path.join( processPath, '__tests__', 'lib', 'in-sample.sql' );
-const writeFilePath = path.join( processPath, '__tests__', 'lib', 'out-sample.sql' );
+const writeFilePath = path.join( tmpDir, 'out-sample.sql' );
 const nonZeroExitCodeScript = path.join( processPath, 'bin', 'non-zero-exit-code.sh' );
 
 beforeEach( () => {

--- a/__tests__/lib/index.test.js
+++ b/__tests__/lib/index.test.js
@@ -82,7 +82,7 @@ describe( 'go-search-replace', () => {
 			async function check() {
 				try {
 					//await replace( readableStream, [ 'thisdomain.com', 'thatdomain.com' ], nonZeroExitCodeScript );
-					await testHarness( [ 'thisdomain.com', 'thatdomain.com' ], nonZeroExitCodeScript );
+					return await testHarness( [ 'thisdomain.com', 'thatdomain.com' ], nonZeroExitCodeScript );
 				} catch ( e ) {
 					throw new Error( e );
 				}

--- a/__tests__/lib/index.test.js
+++ b/__tests__/lib/index.test.js
@@ -76,17 +76,14 @@ describe( 'go-search-replace', () => {
 		} );
 
 		it( 'throws a new Error when the script/binary returns a non-zero exit code', () => {
-			async function whatever() {
+			async function asyncFunc() {
 				try {
 					await replace( readableStream, [ 'thisdomain.com', 'thatdomain.com' ], nonZeroExitCodeScript );
 				} catch ( error ) {
 					throw new Error( error );
 				}
 			}
-			expect( whatever()
-				.catch( error => {
-					throw new Error( error );
-				} ) )
+			expect( asyncFunc() )
 				.rejects
 				.toThrowError( 'The search and replace process exited with a non-zero exit code: 1' );
 		} );

--- a/bin/non-zero-exit-code.sh
+++ b/bin/non-zero-exit-code.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 1

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,6 +89,7 @@ async function replace( streamObj, replacements, binary = null ) {
 	}
 
 	debug( 'Go binaries are installed' );
+	debug( 'useBinary: ', useBinary );
 
 	const replaceProcess = spawn( useBinary, replacements, {
 		stdio: [ 'pipe', 'pipe', process.stderr ],
@@ -100,7 +101,7 @@ async function replace( streamObj, replacements, binary = null ) {
 			process.exit( 1 );
 		} )
 		.on( 'exit', code => {
-			if ( null !== code ) {
+			if ( ! [ null, 0 ].includes( code ) ) {
 				throw new Error( `The search and replace process exited with a non-zero exit code: ${ code }` );
 			}
 		} );

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ async function replace( streamObj, replacements, binary = null ) {
 			console.error( err );
 		}
 	} else {
-		debug( 'NOT DOWNLOADING A BINARY' );
+		debug( 'NOT DOWNLOADING A BINARY', binary );
 	}
 
 	debug( 'Go binaries are installed' );
@@ -100,7 +100,8 @@ async function replace( streamObj, replacements, binary = null ) {
 			console.error( '\n' + err.toString() );
 			process.exit( 1 );
 		} )
-		.on( 'exit', code => {
+		.on( 'close', code => {
+			debug( 'replaceProcess close code', code );
 			if ( ! [ null, 0 ].includes( code ) ) {
 				throw new Error( `The search and replace process exited with a non-zero exit code: ${ code }` );
 			}
@@ -111,6 +112,7 @@ async function replace( streamObj, replacements, binary = null ) {
 	} );
 	streamObj.pipe( replaceProcess.stdin );
 	streamObj = replaceProcess.stdout;
+
 	return streamObj;
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,11 +93,17 @@ async function replace( streamObj, replacements, binary = null ) {
 	const replaceProcess = spawn( useBinary, replacements, {
 		stdio: [ 'pipe', 'pipe', process.stderr ],
 	} );
-	replaceProcess.on( 'error', err => {
-		debug( 'Replace Process Error:', err );
-		console.error( '\n' + err.toString() );
-		process.exit( 1 );
-	} );
+	replaceProcess
+		.on( 'error', err => {
+			debug( 'Replace Process Error:', err );
+			console.error( '\n' + err.toString() );
+			process.exit( 1 );
+		} )
+		.on( 'exit', code => {
+			if ( null !== code ) {
+				throw new Error( `The search and replace process exited with a non-zero exit code: ${ code }` );
+			}
+		} );
 
 	streamObj.on( 'error', error => {
 		console.error( error );

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,58 +62,61 @@ function validate( streamObj, replacements ) {
  * @return {Readable} streamObj
  */
 async function replace( streamObj, replacements, binary = null ) {
-	const valid = validate( streamObj, replacements );
-	if ( ! valid ) {
-		process.exit( 1 );
-	}
-	debug( 'The supplied arguments are valid' );
-
-	if ( ! replacements.length ) {
-		debug( 'No replacements were provided to search and replace with.' );
-		return streamObj;
-	}
-
-	let useBinary = binary || 'go-search-replace';
-
-	// only download the binary if we didn't supply one
-	if ( binary === null ) {
-		try {
-			const downloaded = await downloadBinary();
-			useBinary = downloaded.path;
-			debug( `Using binary at path: ${ useBinary }` );
-		} catch ( err ) {
-			console.error( err );
-		}
-	} else {
-		debug( 'NOT DOWNLOADING A BINARY', binary );
-	}
-
-	debug( 'Go binaries are installed' );
-	debug( 'useBinary: ', useBinary );
-
-	const replaceProcess = spawn( useBinary, replacements, {
-		stdio: [ 'pipe', 'pipe', process.stderr ],
-	} );
-	replaceProcess
-		.on( 'error', err => {
-			debug( 'Replace Process Error:', err );
-			console.error( '\n' + err.toString() );
+	return new Promise( async ( resolve, reject ) => {
+		const valid = validate( streamObj, replacements );
+		if ( ! valid ) {
 			process.exit( 1 );
-		} )
-		.on( 'close', code => {
-			debug( 'replaceProcess close code', code );
-			if ( ! [ null, 0 ].includes( code ) ) {
-				throw new Error( `The search and replace process exited with a non-zero exit code: ${ code }` );
+		}
+		debug( 'The supplied arguments are valid' );
+
+		if ( ! replacements.length ) {
+			debug( 'No replacements were provided to search and replace with.' );
+			return resolve( streamObj );
+		}
+
+		let useBinary = binary || 'go-search-replace';
+
+		// only download the binary if we didn't supply one
+		if ( binary === null ) {
+			try {
+				const downloaded = await downloadBinary();
+				useBinary = downloaded.path;
+				debug( `Using binary at path: ${ useBinary }` );
+			} catch ( err ) {
+				console.error( err );
+				process.exit( 1 );
 			}
+		} else {
+			debug( 'NOT DOWNLOADING A BINARY', binary );
+		}
+
+		debug( 'Go binaries are installed' );
+		debug( 'useBinary: ', useBinary );
+
+		const replaceProcess = spawn( useBinary, replacements, {
+			stdio: [ 'pipe', 'pipe', process.stderr ],
 		} );
+		replaceProcess
+			.on( 'error', err => {
+				debug( 'Replace Process Error:', err );
+				console.error( '\n' + err.toString() );
+				process.exit( 1 );
+			} )
+			.on( 'close', code => {
+				debug( 'replaceProcess close code', code );
+				if ( ! [ null, 0 ].includes( code ) ) {
+					reject( `The search and replace process exited with a non-zero exit code: ${ code }` );
+				}
+			} );
 
-	streamObj.on( 'error', error => {
-		console.error( error );
+		streamObj
+			.pipe( replaceProcess.stdin )
+			.on( 'error', error => {
+				console.error( error );
+				reject( error );
+			} )
+			.on( 'finish', () => resolve( replaceProcess.stdout ) );
 	} );
-	streamObj.pipe( replaceProcess.stdin );
-	streamObj = replaceProcess.stdout;
-
-	return streamObj;
 }
 
 module.exports = {


### PR DESCRIPTION
Listens for a non-zero exit code and throws loudly if one is received.


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.2)_