### PR TITLE
fix: Attach stream listeners prior to starting flow

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,14 +109,18 @@ async function replace( streamObj, replacements, binary = null ) {
 				}
 			} );
 
-		streamObj
-			.pipe( replaceProcess.stdin )
-			.on( 'error', error => {
-				console.error( error );
-				reject( error );
-			} );
+		const streaming = new Promise( ( streamResolve, streamReject ) => {
+			streamObj
+				.on( 'close', streamResolve )
+				.on( 'error', error => {
+					console.error( error );
+					streamReject( error );
+				} );
+		} );
 
-		await new Promise( res => streamObj.on( 'close', res ) );
+		streamObj.pipe( replaceProcess.stdin );
+
+		await streaming;
 
 		resolve( replaceProcess.stdout );
 	} );


### PR DESCRIPTION
Otherwise, there's a chance the stream will process before the listeners are attached.

It might not have manifested in this case as the sink is probably not yet attached in the caller, but this could prevent bugs in the future.