### PR TITLE
fix: Don't block at all, just return output stream

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,68 +62,55 @@ function validate( streamObj, replacements ) {
  * @return {Readable} streamObj
  */
 async function replace( streamObj, replacements, binary = null ) {
-	return new Promise( async ( resolve, reject ) => {
-		const valid = validate( streamObj, replacements );
-		if ( ! valid ) {
-			process.exit( 1 );
-		}
-		debug( 'The supplied arguments are valid' );
+	const valid = validate( streamObj, replacements );
+	if ( ! valid ) {
+		process.exit( 1 );
+	}
+	debug( 'The supplied arguments are valid' );
 
-		if ( ! replacements.length ) {
-			debug( 'No replacements were provided to search and replace with.' );
-			return resolve( streamObj );
-		}
+	if ( ! replacements.length ) {
+		debug( 'No replacements were provided to search and replace with.' );
+		return streamObj;
+	}
 
-		let useBinary = binary || 'go-search-replace';
+	let useBinary = binary || 'go-search-replace';
 
-		// only download the binary if we didn't supply one
-		if ( binary === null ) {
-			try {
-				const downloaded = await downloadBinary();
-				useBinary = downloaded.path;
-				debug( `Using binary at path: ${ useBinary }` );
-			} catch ( err ) {
-				console.error( err );
-				process.exit( 1 );
-			}
-		} else {
-			debug( 'NOT DOWNLOADING A BINARY', binary );
-		}
+	// only download the binary if we didn't supply one
+	if ( binary === null ) {
+		const downloaded = await downloadBinary();
+		useBinary = downloaded.path;
+		debug( `Using binary at path: ${ useBinary }` );
+	} else {
+		debug( 'NOT DOWNLOADING A BINARY', binary );
+	}
 
-		debug( 'Go binaries are installed' );
-		debug( 'useBinary: ', useBinary );
+	debug( 'Go binaries are installed' );
+	debug( 'useBinary: ', useBinary );
 
-		const replaceProcess = spawn( useBinary, replacements, {
-			stdio: [ 'pipe', 'pipe', process.stderr ],
-		} );
-		replaceProcess
-			.on( 'error', err => {
-				debug( 'Replace Process Error:', err );
-				console.error( '\n' + err.toString() );
-				process.exit( 1 );
-			} )
-			.on( 'exit', code => {
-				debug( 'replaceProcess exit code', code );
-				if ( ! [ null, 0 ].includes( code ) ) {
-					reject( `The search and replace process exited with a non-zero exit code: ${ code }` );
-				}
-			} );
-
-		const streaming = new Promise( ( streamResolve, streamReject ) => {
-			streamObj
-				.on( 'close', streamResolve )
-				.on( 'error', error => {
-					console.error( error );
-					streamReject( error );
-				} );
-		} );
-
-		streamObj.pipe( replaceProcess.stdin );
-
-		await streaming;
-
-		resolve( replaceProcess.stdout );
+	const replaceProcess = spawn( useBinary, replacements, {
+		stdio: [ 'pipe', 'pipe', process.stderr ],
 	} );
+	replaceProcess
+		.on( 'error', err => {
+			debug( 'Replace Process Error:', err );
+			console.error( '\n' + err.toString() );
+			process.exit( 1 );
+		} )
+		.on( 'exit', code => {
+			debug( 'replaceProcess exit code', code );
+			if ( code ) {
+				process.exit( code );
+			}
+		} );
+
+	streamObj
+		.on( 'error', error => {
+			console.error( `Error processing input file: ${ error }` );
+			process.exit( 1 );
+		} )
+		.pipe( replaceProcess.stdin );
+
+	return replaceProcess.stdout;
 }
 
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@
  * External dependencies
  */
 const { spawn } = require( 'child_process' );
+const { PassThrough } = require( 'stream' );
 const stream = require( 'stream' );
 const debug = require( 'debug' )( 'vip-search-replace:index' );
 
@@ -90,27 +91,39 @@ async function replace( streamObj, replacements, binary = null ) {
 	const replaceProcess = spawn( useBinary, replacements, {
 		stdio: [ 'pipe', 'pipe', process.stderr ],
 	} );
-	replaceProcess
-		.on( 'error', err => {
-			debug( 'Replace Process Error:', err );
-			console.error( '\n' + err.toString() );
-			process.exit( 1 );
-		} )
-		.on( 'exit', code => {
-			debug( 'replaceProcess exit code', code );
-			if ( code ) {
-				process.exit( code );
-			}
-		} );
 
-	streamObj
-		.on( 'error', error => {
-			console.error( `Error processing input file: ${ error }` );
-			process.exit( 1 );
-		} )
-		.pipe( replaceProcess.stdin );
+	// Allow the output stream to outlive the child process
+	const outStream = replaceProcess.stdout.pipe( new PassThrough() );
 
-	return replaceProcess.stdout;
+	await new Promise( ( resolve, reject ) => {
+		streamObj
+			.on( 'error', error => {
+				reject( `Error processing input file: ${ error }` );
+			} );
+
+		replaceProcess
+			.on( 'error', err => {
+				reject( `Replace process error: ${ err }` );
+			} )
+			.on( 'exit', code => {
+				if ( code ) {
+					return reject( `The search and replace process exited with a non-zero exit code: ${ code }` );
+				}
+				debug( 'Replace process returned cleanly' );
+			} );
+
+		/**
+		 * Once the binary starts printing to stdout, there are no more exits to trap:
+		 * https://github.com/Automattic/go-search-replace/blob/d99c5b45d3b3c870b1bad186941a3688a452d491/search-replace.go#L86
+		 * Assume it will always be that way :)
+		 */
+		replaceProcess.stdout.on( 'data', resolve );
+
+		// let it flow;
+		streamObj.pipe( replaceProcess.stdin );
+	} );
+
+	return outStream;
 }
 
 module.exports = {


### PR DESCRIPTION
If I ran this with a larger file (~70mb), it was stalling. This lib was blocking on completion of the input file before returning the output stream, but, if the file was larger than the buffer, it seems it never made it to the caller's output stream.

This change pipes the stdout stream of the child process into a [PassThrough stream](https://nodejs.org/api/stream.html#stream_class_stream_passthrough) and returns that so it outlives the child process on exit.

Additionally, we're resolving the promise with the output stream once the child process starts writing to its output stream as there are no further intentional exists past that point. This allows for memory-efficient stream processing.

## Test plan

### Automated tests

`npm test` should all still pass

### Manual tests

* Apply this change to the dependency in the CLI (`npm i --save "Automattic/vip-search-replace#81902c1"`)
* The standalone search and replace command should now work with larger files
* The import command with search and replace options should now work with larger files