### PR TITLE
Refactor install lib and script -- download binary to package dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build
 node_modules/
-bin/go-search-replace
+bin/go-search-replace*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 node_modules/
+bin/go-search-replace

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Automattic
+Copyright (c) 2021 Automattic
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/__tests__/lib/index.test.js
+++ b/__tests__/lib/index.test.js
@@ -25,7 +25,6 @@ afterEach( () => {
 	if ( fs.existsSync( writeFilePath ) ) {
 		fs.unlinkSync( writeFilePath );
 	}
-	fs.truncateSync( path.join( processPath, 'bin', 'go-search-replace' ) );
 } );
 
 async function testHarness( replacements, customScript = null ) {

--- a/bin/install-binary.js
+++ b/bin/install-binary.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*
  * MIT License
  *

--- a/bin/install-binary.js
+++ b/bin/install-binary.js
@@ -22,23 +22,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-const path = require( 'path' );
+const { ARCH_MAPPING, installBinary, PLATFORM_MAPPING } = require( '../lib/install-go-binary' );
 
-const downloadBinary = require( './install-go-binary' );
+const [ platform, arch, writePath ] = process.argv.slice( 2 );
 
-// auto execute an async function
-( async () => {
-	const arch = 'amd64';
-	const platform = 'linux';
-	const latestBinaryVersion = '0.0.5';
-	const URL = 'https://github.com/Automattic/go-search-replace/releases/download/{{version}}/go-search-replace_{{platform}}_{{arch}}.gz';
+function printUsage() {
+	console.log( `
+Usage: ${ process.argv.slice( 0, 1 ).join( ' ' ) } <platform> <arch> <writePath>
 
-	const url = URL
-		.replace( /{{arch}}/, arch )
-		.replace( /{{platform}}/, platform )
-		.replace( /{{version}}/, latestBinaryVersion );
+  All options are optional and will default to values from your process env.
 
-	const writePath = path.join( process.cwd(), 'bin', 'go-search-replace-test' );
+  * Valid values for platform: ${ Object.keys( PLATFORM_MAPPING ).join( ', ' ) }
+  * Valid values for arch: ${ Object.keys( ARCH_MAPPING ).join( ', ' ) }
+  * writePath defaults to: <package-install-dir>/bin/go-search-replace
+` );
+}
 
-	await downloadBinary( url, writePath );
-} )();
+if ( [ '-h', 'help', '--help', 'usage' ].includes( platform ) ) {
+	printUsage();
+	process.exit( 0 );
+}
+
+installBinary( { arch, platform, writePath } )
+	.then( result => console.log( `✅ Installed ${ result.platform }:${ result.arch } binary to: ${ result.path }` ) )
+	.catch( () => {
+		console.error( 'Installed Failed: Check command line arguments.' );
+		printUsage();
+		process.exit( 1 );
+	} );

--- a/lib/get-test-binary.js
+++ b/lib/get-test-binary.js
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2018 Automattic
+ * Copyright (c) 2021 Automattic
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2018 Automattic
+ * Copyright (c) 2021 Automattic
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ const debug = require( 'debug' )( 'vip-search-replace:index' );
 /**
  * Internal dependencies
  */
-const downloadBinary = require( './install-go-binary' );
+const { installBinary } = require( './install-go-binary' );
 
 /**
  * Validate the library inputs
@@ -78,8 +78,8 @@ async function replace( streamObj, replacements, binary = null ) {
 
 	// only download the binary if we didn't supply one
 	if ( binary === null ) {
-		const downloaded = await downloadBinary();
-		useBinary = downloaded.path;
+		const installed = await installBinary();
+		useBinary = installed.path;
 		debug( `Using binary at path: ${ useBinary }` );
 	} else {
 		debug( 'NOT DOWNLOADING A BINARY', binary );

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -22,17 +22,10 @@
  * SOFTWARE.
  */
 const { https } = require( 'follow-redirects' );
-const gunzip = require( 'zlib' ).createGunzip();
+const { createGunzip } = require( 'zlib' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 const debug = require( 'debug' )( 'vip-search-replace:install-go-binary' );
-
-// Ensure build path exists
-const binPath = path.join( process.cwd(), 'bin', 'go-search-replace' );
-debug( binPath );
-if ( ! fs.existsSync( path.dirname( binPath ) ) ) {
-	fs.mkdirSync( path.dirname( binPath ) );
-}
 
 // Mapping from Node's `process.arch` to Golang's `$GOARCH`
 const ARCH_MAPPING = {
@@ -49,38 +42,94 @@ const PLATFORM_MAPPING = {
 	freebsd: 'freebsd',
 };
 
-function getLatestReleaseUrlForPlatformAndArch() {
-	// Windows executables compiled by Golang have a `.exe` extension
-	const arch = `${ ARCH_MAPPING[ process.arch ] }${ process.platform === 'win32' ? '.exe' : '' }`;
-
-	return 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_{{platform}}_{{arch}}.gz'
-		.replace( /{{arch}}/, arch )
-		.replace( /{{platform}}/, PLATFORM_MAPPING[ process.platform ] );
+function getLatestReleaseUrlForPlatformAndArch( { platform, arch } = {} ) {
+	const _platform = PLATFORM_MAPPING[ platform ];
+	if ( ! _platform ) {
+		throw new Error( 'Invalid platform type' );
+	}
+	const _arch = ARCH_MAPPING[ arch ];
+	if ( ! _arch ) {
+		throw new Error( 'Invalid arch type' );
+	}
+	const suffix = platform === 'win32' ? '.exe' : '';
+	return `https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_${ _platform }_${ _arch }${ suffix }.gz`;
 }
 
-const downloadBinary = ( url = getLatestReleaseUrlForPlatformAndArch(), writePath = null ) => {
+async function downloadBinary( { arch = process.arch, platform = process.platform } = {} ) {
+	const url = getLatestReleaseUrlForPlatformAndArch( { platform, arch } );
+
 	return new Promise( ( resolve, reject ) => {
 		debug( 'Requested URL: ', url );
-		https.request( url, res => {
-			debug( JSON.stringify( { statusCode: res.statusCode, responseUrl: res.responseUrl } ) );
-			const writeTo = writePath || binPath;
-			const writeStream = fs.createWriteStream( writeTo, { mode: 0o755 } );
-			writeStream.on( 'error', writeErr => {
-				console.error( writeErr );
-				reject( writeErr );
-			} );
-			writeStream.on( 'finish', () => {
-				debug( `Downloaded & unpacked binary to path: ${ writeTo }` );
-				resolve( { path: writeTo } );
-			} );
-			res.pipe( gunzip ).pipe( writeStream );
-		} )
+		https
+			.request( url, res => {
+				debug( JSON.stringify( { statusCode: res.statusCode, responseUrl: res.responseUrl } ) );
+				resolve( res );
+			} )
 			.on( 'error', err => {
 				debug( 'ERROR:', err );
 				reject( err );
 			} )
 			.end();
 	} );
-};
+}
 
-module.exports = downloadBinary;
+async function installBinary( { arch = process.arch, platform = process.platform, writePath = null } = {} ) {
+	let writeTo;
+
+	if ( writePath ) {
+		writeTo = writePath;
+	} else {
+		const binDir = path.join( path.dirname( __dirname ), 'bin' );
+		debug( { binDir } );
+		try {
+			// Ensure build path exists
+			await fs.promises.mkdir( binDir, { recursive: true } );
+		} catch ( mkdirError ) {
+			debug( { mkdirError } );
+			throw mkdirError;
+		}
+		const binPath = path.join( binDir, 'go-search-replace' );
+		debug( { binPath } );
+		writeTo = binPath;
+	}
+
+	return new Promise( async ( resolve, reject ) => {
+		let responseStream;
+		try {
+			responseStream = await downloadBinary( { platform, arch } );
+		} catch ( downloadErr ) {
+			debug( { downloadErr } );
+			return reject( downloadErr );
+		}
+
+		const writeStream = fs.createWriteStream( writeTo, { mode: 0o755 } );
+		writeStream.on( 'error', writeErr => {
+			debug( { writeErr } );
+			reject( writeErr );
+		} );
+		writeStream.on( 'finish', () => {
+			debug( `Installed binary to path: ${ writeTo }` );
+			resolve( {
+				arch,
+				path: writeTo,
+				platform,
+			} );
+		} );
+
+		const gunzip = createGunzip();
+		gunzip.on( 'error', gunzipErr => {
+			debug( { gunzipErr } );
+			reject( gunzipErr );
+		} );
+
+		responseStream.pipe( gunzip ).pipe( writeStream );
+	} );
+}
+
+module.exports = {
+	ARCH_MAPPING,
+	downloadBinary,
+	installBinary,
+	getLatestReleaseUrlForPlatformAndArch,
+	PLATFORM_MAPPING,
+};

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -42,6 +42,10 @@ const PLATFORM_MAPPING = {
 	freebsd: 'freebsd',
 };
 
+function getBinSuffix( platform ) {
+	return [ 'win32', 'windows' ].includes( platform ) ? '.exe' : '';
+}
+
 function getLatestReleaseUrlForPlatformAndArch( { platform, arch } = {} ) {
 	const _platform = PLATFORM_MAPPING[ platform ];
 	if ( ! _platform ) {
@@ -51,8 +55,7 @@ function getLatestReleaseUrlForPlatformAndArch( { platform, arch } = {} ) {
 	if ( ! _arch ) {
 		throw new Error( 'Invalid arch type' );
 	}
-	const suffix = platform === 'win32' ? '.exe' : '';
-	return `https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_${ _platform }_${ _arch }${ suffix }.gz`;
+	return `https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_${ _platform }_${ _arch }${ getBinSuffix( _platform ) }.gz`;
 }
 
 async function downloadBinary( { arch = process.arch, platform = process.platform } = {} ) {
@@ -88,10 +91,10 @@ async function installBinary( { arch = process.arch, platform = process.platform
 			debug( { mkdirError } );
 			throw mkdirError;
 		}
-		const binPath = path.join( binDir, 'go-search-replace' );
-		debug( { binPath } );
-		writeTo = binPath;
+		writeTo = `${ path.join( binDir, 'go-search-replace' ) }${ getBinSuffix( platform ) }`;
 	}
+
+	debug( { writeTo } );
 
 	return new Promise( async ( resolve, reject ) => {
 		let responseStream;

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2018 Automattic
+ * Copyright (c) 2021 Automattic
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -5869,6 +5869,12 @@
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -6236,6 +6242,18 @@
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
+      }
+    },
+    "nock": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.7.tgz",
+      "integrity": "sha512-WBz73VYIjdbO6BwmXODRQLtn7B5tldA9pNpWJe5QTtTEscQlY5KXU4srnGzBOK2fWakkXj69gfTnXGzmrsaRWw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
       }
     },
     "node-int64": {
@@ -6747,6 +6765,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A Node package interface to a Go powered search and replace package",
   "main": "lib/index.js",
   "scripts": {
-    "download-test-binary": "node lib/get-test-binary.js",
+    "download-binary": "node ./bin/install-binary",
+    "download-test-binary": "npm run download-binary linux x64 ./bin/go-search-replace-test",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "jest --silent",
@@ -20,10 +21,6 @@
     "url": "https://github.com/Automattic/vip-search-replace/issues"
   },
   "homepage": "https://github.com/Automattic/vip-search-replace#readme",
-  "bin": {
-    "go-search-replace": "bin/go-search-replace",
-    "go-search-replace-test": "bin/go-search-replace-test"
-  },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "eslint": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "nlm": {
     "license": {
       "files": [
+        "bin",
         "lib",
         "test"
       ]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "download-test-binary": "npm run download-binary linux x64 ./bin/go-search-replace-test",
     "lint": "eslint .",
     "pretest": "npm run lint",
-    "test": "jest --silent",
+    "test": "jest",
     "posttest": "nlm verify"
   },
   "repository": {
@@ -35,7 +35,8 @@
     "eslint-plugin-react": "^7.21.3",
     "eslint-plugin-wpcalypso": "^4.1.0",
     "jest": "^26.4.2",
-    "nlm": "^5.1.0"
+    "nlm": "^5.1.0",
+    "nock": "^13.0.7"
   },
   "nlm": {
     "license": {


### PR DESCRIPTION
Currently, the binary is downloaded to a dir named `./bin` relative to the current working directory. This is suboptimal in the case of the [CLI](https://github.com/Automattic/vip/). We want to leave the caller's file system tidy.

This change aims to download the file to the directory where this package is installed.

Along the way, I've done some refactoring and added tests.

## Changes

### Usage Enhancements

* Write the binary to the package dir instead of the current dir
* The script that previously fetched the current "test binary" (e.g. the x64 linux binary for use in CI) was generalized to allow fetching arbitrary binaries
* Usage examples are printed for the above script when requested on the CLI & on failure
* Split out functions to be more composable and independently testable

### Expanded Test Coverage

* mock / spyOn `console.error`s in the validate tests
* Thanks to the above item, we can now avoid the `--silent` flag for jest
* Cover arch and platform constants
* Cover `getLatestReleaseUrlForPlatformAndArch()`
* Cover the newly split out `downloadBinary()` (uses nock to mock network call)

### Behind the Scenes

* Bump copyright date
* No longer install executables into the PATH (via package.json bin)
* Include bin in the nlm license files list

## To Test

### Automated Tests

`npm t`

### Manual Tests

* Check CI test binary update workflow:
    * `npm run download-test-binary` should download the latest linux:x64 binary to `./bin/go-search-replace-test`.
        * Unless the upstream is bumped, this should result in no changes to the working directory (we'll run this when it gets bumped)
* Check the new "current env" binary download workflow:
    * `rm ./bin/go-search-replace *` (Make sure any previous non-test binaries / placeholders are removed)
    * `npm run download-binary`
        * The binary for your environment's platform and architecture should be downloaded to `./bin/go-search-replace`
        * It should be executable via `./bin/go-search-replace` (or `./bin/go-search-replace.exe` on Windows)
* Check the new arbitrary binary download workflow:
    * `npm run download-binary help`
        * Confirm the usage examples are straightforward and make sense
    * Provide various platforms and archs that do not match your current system
        * Confirm that the appropriate binary gets downloaded
* Check this version with the CLI
    * checkout the [CLI](https://github.com/Automattic/vip/) & cd into its dir
    * `git fetch`
    * `git checkout origin/master`
    * `npm i`
    * `npm i --save "https://github.com/Automattic/vip-search-replace.git#update/binary-locations"`
    * `npm run build`
    * `rm -r bin` (to make sure there are no remnant binaries in the cwd)
    * `./dist/bin/vip-search-replace.js -s "from.example.com,to.example.com" /path/to/dbdump.sql`
        * Search and Replace should work as before
        * Your working directory should be clean -- No `./bin` directory should be created in your current working directory
        * Checksums should match for the installed binary & the currently released binary for your env.  For example, on an Intel Mac with a recent OS, these should both match `3df2769c01ebaf78eb2096c8390a50b6`:
            * `curl -L -o - https://github.com/Automattic/go-search-replace/releases/download/0.0.5/go-search-replace_darwin_amd64.gz | gunzip -f | md5sum -b`
            * `md5sum -b ./node_modules/@automattic/vip/node_modules/@automattic/vip-search-replace/bin/go-search-replace`
    * Search and replace in the sql import command should still work as well