### PR TITLE
Fall back to a temp dir when unable to access package dir

### DIFF
--- a/bin/install-binary.js
+++ b/bin/install-binary.js
@@ -45,8 +45,9 @@ if ( [ '-h', 'help', '--help', 'usage' ].includes( platform ) ) {
 
 installBinary( { arch, platform, writePath } )
 	.then( result => console.log( `✅ Installed ${ result.platform }:${ result.arch } binary to: ${ result.path }` ) )
-	.catch( () => {
-		console.error( 'Installed Failed: Check command line arguments.' );
+	.catch( err => {
+		console.error( 'Installed Failed: Check command line arguments and file system settings.' );
+		console.error( err );
 		printUsage();
 		process.exit( 1 );
 	} );

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,9 +78,14 @@ async function replace( streamObj, replacements, binary = null ) {
 
 	// only download the binary if we didn't supply one
 	if ( binary === null ) {
-		const installed = await installBinary();
-		useBinary = installed.path;
-		debug( `Using binary at path: ${ useBinary }` );
+		try {
+			const installed = await installBinary();
+			useBinary = installed.path;
+			debug( `Using binary at path: ${ useBinary }` );
+		} catch ( err ) {
+			debug( `Error installing binary: ${ err }` );
+			return err;
+		}
 	} else {
 		debug( 'NOT DOWNLOADING A BINARY', binary );
 	}

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -24,6 +24,7 @@
 const { https } = require( 'follow-redirects' );
 const { createGunzip } = require( 'zlib' );
 const fs = require( 'fs' );
+const os = require( 'os' );
 const path = require( 'path' );
 const debug = require( 'debug' )( 'vip-search-replace:install-go-binary' );
 
@@ -76,25 +77,49 @@ async function downloadBinary( { arch = process.arch, platform = process.platfor
 	} );
 }
 
+async function getInstallDir() {
+	const binDir = path.join( path.dirname( __dirname ), 'bin' );
+	debug( `Trying dir: ${ binDir }` );
+	try {
+		// Ensure the dir exists
+		await fs.promises.mkdir( binDir, { recursive: true } );
+
+		debug( 'Path to dir is ok' );
+
+		// Ensure the dir is writeable
+		await fs.promises.access( binDir, fs.constants.W_OK );
+
+		debug( 'Dir is writable' );
+
+		return binDir;
+	} catch ( err ) {}
+
+	// Either cannot create or write to the package dir, fall back to a temporary dir
+	debug( 'Falling back to a temporary dir' );
+
+	return fs.promises.mkdtemp( path.join( os.tmpdir(), 'vip-search-replace-' ) );
+}
+
 async function installBinary( { arch = process.arch, platform = process.platform, writePath = null } = {} ) {
 	let writeTo;
 
 	if ( writePath ) {
 		writeTo = writePath;
 	} else {
-		const binDir = path.join( path.dirname( __dirname ), 'bin' );
-		debug( { binDir } );
-		try {
-			// Ensure build path exists
-			await fs.promises.mkdir( binDir, { recursive: true } );
-		} catch ( mkdirError ) {
-			debug( { mkdirError } );
-			throw mkdirError;
-		}
+		const binDir = await getInstallDir();
 		writeTo = `${ path.join( binDir, 'go-search-replace' ) }${ getBinSuffix( platform ) }`;
 	}
 
-	debug( { writeTo } );
+	debug( `Attempting to open for writing: ${ writeTo }` );
+
+	let fd;
+	try {
+		fd = await fs.promises.open( writeTo, 'w', 0o755 );
+	} catch ( err ) {
+		return Promise.reject( `Could not open the destination file for writing: ${ err }` );
+	}
+
+	debug( 'OK to write.' );
 
 	return new Promise( async ( resolve, reject ) => {
 		let responseStream;
@@ -105,10 +130,12 @@ async function installBinary( { arch = process.arch, platform = process.platform
 			return reject( downloadErr );
 		}
 
-		const writeStream = fs.createWriteStream( writeTo, { mode: 0o755 } );
+		debug( 'Download stream is OK.' );
+
+		const writeStream = fs.createWriteStream( writeTo, { fd } );
 		writeStream.on( 'error', writeErr => {
 			debug( { writeErr } );
-			reject( writeErr );
+			reject( `Could not complete file write: ${ writeErr }` );
 		} );
 		writeStream.on( 'finish', () => {
 			debug( `Installed binary to path: ${ writeTo }` );
@@ -122,7 +149,7 @@ async function installBinary( { arch = process.arch, platform = process.platform
 		const gunzip = createGunzip();
 		gunzip.on( 'error', gunzipErr => {
 			debug( { gunzipErr } );
-			reject( gunzipErr );
+			reject( `Could not complete file decompression: ${ gunzipErr }` );
 		} );
 
 		responseStream.pipe( gunzip ).pipe( writeStream );
@@ -132,7 +159,8 @@ async function installBinary( { arch = process.arch, platform = process.platform
 module.exports = {
 	ARCH_MAPPING,
 	downloadBinary,
-	installBinary,
+	getInstallDir,
 	getLatestReleaseUrlForPlatformAndArch,
+	installBinary,
 	PLATFORM_MAPPING,
 };


### PR DESCRIPTION
Discussion:
https://a8c.slack.com/archives/C50USFF0Q/p1612897928004400
https://a8c.slack.com/archives/C50USFF0Q/p1612908455006300?thread_ts=1612899606.005300&cid=C50USFF0Q

We need to do a better job of handling cases where we cannot write to our desired location. Previously, it was the current working dir. Now, it's the package dir.

In either case, there's a possibility that the file system is mounted read-only or the user running this package does not have access to write to it.

This change adds improved handling of those cases and uses a temp dir as a fall back.

This also adds additional test coverage of the above.