### PR TITLE
fix: Explicitly close file descriptor after install

### DIFF
--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -135,10 +135,12 @@ async function installBinary( { arch = process.arch, platform = process.platform
 		const writeStream = fs.createWriteStream( writeTo, { fd } );
 		writeStream.on( 'error', writeErr => {
 			debug( { writeErr } );
+			fd.close();
 			reject( `Could not complete file write: ${ writeErr }` );
 		} );
 		writeStream.on( 'finish', () => {
 			debug( `Installed binary to path: ${ writeTo }` );
+			fd.close();
 			resolve( {
 				arch,
 				path: writeTo,


### PR DESCRIPTION
I'm getting a warning pop up like this that is only noticeable if we pipe to a pager (e.g. `vip search-replace -s "from.example.com,to.example.com" ./somefile.sql | less`):

```
Warning: Closing file descriptor 25 on garbage collection
(Use `node --trace-warnings ...` to show where the warning was created)
(node:13813) [DEP0137] DeprecationWarning: Closing a FileHandle object on garbage collection is deprecated. Please close FileHandle objects explicitly using FileHandle.prototype.close(). In the future, an error will be thrown if a file descriptor is closed during garbage collection.```

This change explicitly closes the file descriptor on stream finish or exit to avoid it.