### PR TITLE
fix: Correct GOARCH. arm64, not arm

### DIFF
--- a/__tests__/lib/index.test.js
+++ b/__tests__/lib/index.test.js
@@ -131,7 +131,7 @@ describe( 'install-go-binary', () => {
 			expect( ARCH_MAPPING ).toEqual( {
 				ia32: '386',
 				x64: 'amd64',
-				arm: 'arm',
+				arm: 'arm64',
 			} );
 		} );
 	} );
@@ -153,7 +153,7 @@ describe( 'install-go-binary', () => {
 
 		it( 'should get a proper macm1 env url', () => {
 			const url = getLatestReleaseUrlForPlatformAndArch( { arch: 'arm', platform: 'darwin' } );
-			expect( url ).toBe( 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_darwin_arm.gz' );
+			expect( url ).toBe( 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_darwin_arm64.gz' );
 		} );
 
 		it( 'should get a proper linux / CI test env url', () => {
@@ -163,7 +163,7 @@ describe( 'install-go-binary', () => {
 
 		it( 'should get a proper alternative env url', () => {
 			const url = getLatestReleaseUrlForPlatformAndArch( { arch: 'arm', platform: 'freebsd' } );
-			expect( url ).toBe( 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_freebsd_arm.gz' );
+			expect( url ).toBe( 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_freebsd_arm64.gz' );
 		} );
 
 		it( 'should get a proper windows url', () => {

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -32,7 +32,7 @@ const debug = require( 'debug' )( 'vip-search-replace:install-go-binary' );
 const ARCH_MAPPING = {
 	ia32: '386',
 	x64: 'amd64',
-	arm: 'arm',
+	arm: 'arm64',
 };
 
 // Mapping between Node's `process.platform` to Golang's


### PR DESCRIPTION
Discussion: https://a8c.slack.com/archives/CKUJZT08Y/p1614192821068000?thread_ts=1614128274.023800&cid=CKUJZT08Y

This should fix it to work on Apple M1 since https://github.com/Automattic/go-search-replace/pull/28