### PR TITLE
fix: Correctly reference the arm64 arch

### DIFF
--- a/__tests__/lib/index.test.js
+++ b/__tests__/lib/index.test.js
@@ -131,7 +131,7 @@ describe( 'install-go-binary', () => {
 			expect( ARCH_MAPPING ).toEqual( {
 				ia32: '386',
 				x64: 'amd64',
-				arm: 'arm64',
+				arm64: 'arm64',
 			} );
 		} );
 	} );
@@ -152,7 +152,7 @@ describe( 'install-go-binary', () => {
 		} );
 
 		it( 'should get a proper macm1 env url', () => {
-			const url = getLatestReleaseUrlForPlatformAndArch( { arch: 'arm', platform: 'darwin' } );
+			const url = getLatestReleaseUrlForPlatformAndArch( { arch: 'arm64', platform: 'darwin' } );
 			expect( url ).toBe( 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_darwin_arm64.gz' );
 		} );
 
@@ -162,7 +162,7 @@ describe( 'install-go-binary', () => {
 		} );
 
 		it( 'should get a proper alternative env url', () => {
-			const url = getLatestReleaseUrlForPlatformAndArch( { arch: 'arm', platform: 'freebsd' } );
+			const url = getLatestReleaseUrlForPlatformAndArch( { arch: 'arm64', platform: 'freebsd' } );
 			expect( url ).toBe( 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_freebsd_arm64.gz' );
 		} );
 

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -32,7 +32,7 @@ const debug = require( 'debug' )( 'vip-search-replace:install-go-binary' );
 const ARCH_MAPPING = {
 	ia32: '386',
 	x64: 'amd64',
-	arm: 'arm64',
+	arm64: 'arm64',
 };
 
 // Mapping between Node's `process.platform` to Golang's


### PR DESCRIPTION
#17 corrected the golang arch, but not the node arch.

This fixes that as well.