### PR TITLE
build: Add allowed list of os & cpu

### DIFF
--- a/__tests__/lib/index.test.js
+++ b/__tests__/lib/index.test.js
@@ -141,7 +141,6 @@ describe( 'install-go-binary', () => {
 			darwin: 'darwin',
 			linux: 'linux',
 			win32: 'windows',
-			freebsd: 'freebsd',
 		} );
 	} );
 
@@ -161,9 +160,9 @@ describe( 'install-go-binary', () => {
 			expect( url ).toBe( 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_linux_amd64.gz' );
 		} );
 
-		it( 'should get a proper alternative env url', () => {
-			const url = getLatestReleaseUrlForPlatformAndArch( { arch: 'arm64', platform: 'freebsd' } );
-			expect( url ).toBe( 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_freebsd_arm64.gz' );
+		it( 'should get a proper 32 bit linux url', () => {
+			const url = getLatestReleaseUrlForPlatformAndArch( { arch: 'ia32', platform: 'linux' } );
+			expect( url ).toBe( 'https://github.com/Automattic/go-search-replace/releases/latest/download/go-search-replace_linux_386.gz' );
 		} );
 
 		it( 'should get a proper windows url', () => {

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -40,7 +40,6 @@ const PLATFORM_MAPPING = {
 	darwin: 'darwin',
 	linux: 'linux',
 	win32: 'windows',
-	freebsd: 'freebsd',
 };
 
 function getBinSuffix( platform ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@automattic/vip-search-replace",
   "version": "1.0.15",
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "ia32",
+    "x64",
+    "arm64"
+  ],
   "description": "A Node package interface to a Go powered search and replace package",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This package won't work for binaries we don't build, so limiting to those that we do.