### PR TITLE
ci: run `nlm verify` manually because it breaks the publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: nlm verify
+        run: npx nlm verify

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/vip-search-replace",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/vip-search-replace",
-      "version": "1.1.2",
+      "version": "1.1.1",
       "cpu": [
         "ia32",
         "x64",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/vip-search-replace",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "os": [
     "darwin",
     "linux",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "download-test-binary": "npm run download-binary linux x64 ./bin/go-search-replace-test",
     "lint": "eslint .",
     "pretest": "npm run lint",
-    "test": "jest",
-    "posttest": "nlm verify"
+    "test": "jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The "Prepare new npm release" workflow updates the version in `package.json`; this breaks `nlm verify` because it expects to find a tag matching the version.

This PR removes the `posttest` script and runs `nlm verify` as the last step of CI.

Ref: https://github.com/Automattic/vip-search-replace/actions/runs/7168464896/job/19516715673