### PR TITLE
chore(deps): bump `follow-redirects` to 1.15.4 to fix CVE-2023-26159

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       ],
       "dependencies": {
         "debug": "^4.2.0",
-        "follow-redirects": "^1.13.0"
+        "follow-redirects": "^1.15.4"
       },
       "devDependencies": {
         "@automattic/eslint-plugin-wpvip": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "debug": "^4.2.0",
-    "follow-redirects": "^1.13.0"
+    "follow-redirects": "^1.15.4"
   },
   "babel": {}
 }


### PR DESCRIPTION
Related: #74
Ref: https://github.com/advisories/GHSA-jchw-25xp-jwwc
