### PR TITLE
refactor: replace `follow-redirects` with native `fetch`

### DIFF
--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -80,16 +80,22 @@ function ensureError( err ) {
 }
 
 /**
- * @param {{ arch?: string, platform?: string }} options
+ * @param {{ arch?: string, platform?: string, timeout?: number }} options
  * @returns {Promise<import('node:stream').Readable>}
  */
-async function downloadBinary( { arch = process.arch, platform = process.platform } = {} ) {
+async function downloadBinary( { arch = process.arch, platform = process.platform, timeout = 0 } = {} ) {
 	const url = getLatestReleaseUrlForPlatformAndArch( { platform, arch } );
 	debug( 'Requested URL: ', url );
+
+	const controller = new AbortController();
+	const timeoutId = timeout > 0 ? setTimeout( () => {
+		controller.abort();
+	}, timeout ) : null;
 
 	try {
 		const response = await fetch( url, {
 			redirect: 'follow',
+			signal: controller.signal,
 		} );
 
 		debug( JSON.stringify( { statusCode: response.status, responseUrl: response.url } ) );
@@ -105,6 +111,10 @@ async function downloadBinary( { arch = process.arch, platform = process.platfor
 	} catch ( err ) {
 		debug( 'ERROR:', err );
 		throw ensureError( err );
+	} finally {
+		if ( timeoutId ) {
+			clearTimeout( timeoutId );
+		}
 	}
 }
 
@@ -149,7 +159,7 @@ async function closeFd( fd ) {
 	}
 }
 
-async function installBinary( { arch = process.arch, platform = process.platform, writePath = null } = {} ) {
+async function installBinary( { arch = process.arch, platform = process.platform, writePath = null, timeout = 0 } = {} ) {
 	let writeTo;
 
 	if ( writePath ) {
@@ -174,7 +184,7 @@ async function installBinary( { arch = process.arch, platform = process.platform
 
 	let responseStream;
 	try {
-		responseStream = await downloadBinary( { platform, arch } );
+		responseStream = await downloadBinary( { platform, arch, timeout } );
 	} catch ( downloadErr ) {
 		debug( { downloadErr } );
 		await closeFd( fd );

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -22,10 +22,10 @@
  * SOFTWARE.
  */
 const debug = require( 'debug' )( 'vip-search-replace:install-go-binary' );
-const { https } = require( 'follow-redirects' );
 const fs = require( 'node:fs' );
 const { tmpdir } = require( 'node:os' );
 const path = require( 'node:path' );
+const { Readable } = require( 'node:stream' );
 const { pipeline } = require( 'node:stream/promises' );
 const { createGunzip } = require( 'node:zlib' );
 
@@ -81,23 +81,31 @@ function ensureError( err ) {
 
 /**
  * @param {{ arch?: string, platform?: string }} options
+ * @returns {Promise<Readable>}
  */
 async function downloadBinary( { arch = process.arch, platform = process.platform } = {} ) {
 	const url = getLatestReleaseUrlForPlatformAndArch( { platform, arch } );
+	debug( 'Requested URL: ', url );
 
-	return new Promise( ( resolve, reject ) => {
-		debug( 'Requested URL: ', url );
-		https
-			.request( url, ( res ) => {
-				debug( JSON.stringify( { statusCode: res.statusCode, responseUrl: res.responseUrl } ) );
-				resolve( res );
-			} )
-			.on( 'error', ( err ) => {
-				debug( 'ERROR:', err );
-				reject( ensureError( err ) );
-			} )
-			.end();
-	} );
+	try {
+		const response = await fetch( url, {
+			redirect: 'follow',
+		} );
+
+		debug( JSON.stringify( { statusCode: response.status, responseUrl: response.url } ) );
+		if ( ! response.ok ) {
+			throw new Error( `Failed to download binary: ${ response.status } ${ response.statusText }` );
+		}
+
+		if ( ! response.body ) {
+			throw new Error( 'Response body is empty' );
+		}
+
+		return Readable.fromWeb( response.body );
+	} catch ( err ) {
+		debug( 'ERROR:', err );
+		throw ensureError( err );
+	}
 }
 
 async function getInstallDir() {

--- a/lib/install-go-binary.js
+++ b/lib/install-go-binary.js
@@ -81,7 +81,7 @@ function ensureError( err ) {
 
 /**
  * @param {{ arch?: string, platform?: string }} options
- * @returns {Promise<Readable>}
+ * @returns {Promise<import('node:stream').Readable>}
  */
 async function downloadBinary( { arch = process.arch, platform = process.platform } = {} ) {
 	const url = getLatestReleaseUrlForPlatformAndArch( { platform, arch } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,7 @@
         "win32"
       ],
       "dependencies": {
-        "debug": "^4.2.0",
-        "follow-redirects": "^1.15.4"
+        "debug": "^4.2.0"
       },
       "devDependencies": {
         "@automattic/eslint-plugin-wpvip": "^0.13.1",
@@ -4437,26 +4436,6 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "debug": "^4.2.0",
-    "follow-redirects": "^1.15.4"
+    "debug": "^4.2.0"
   },
   "babel": {}
 }


### PR DESCRIPTION
This pull request refactors the `lib/install-go-binary.js` file to improve the binary download process by replacing the `follow-redirects` library with the native `fetch` API, adds support for a timeout parameter, and updates the `package.json` file to remove an unused dependency.

### Refactoring and improvements to binary download:

* Replaced the `follow-redirects` library with the native `fetch` API for downloading binaries, simplifying the code and adding better error handling. (`lib/install-go-binary.js`)
* Added a `timeout` parameter to the `downloadBinary` and `installBinary` functions, allowing the download process to be aborted if it exceeds the specified time limit. (`lib/install-go-binary.js`) [[1]](diffhunk://#diff-c7b2d53bf0f40ea60412b05394aff72749845bbbd1d7e217266f69431d8f9767L83-R118) [[2]](diffhunk://#diff-c7b2d53bf0f40ea60412b05394aff72749845bbbd1d7e217266f69431d8f9767L144-R162) [[3]](diffhunk://#diff-c7b2d53bf0f40ea60412b05394aff72749845bbbd1d7e217266f69431d8f9767L169-R187)

### Dependency updates:

* Removed the `follow-redirects` dependency from `package.json` as it is no longer used. (`package.json`)