### PR TITLE
fix: code scanning alerts

### DIFF
--- a/.github/workflows/npm-prepare-release.yml
+++ b/.github/workflows/npm-prepare-release.yml
@@ -14,10 +14,16 @@ on:
           - minor
           - major
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare a new npm release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out the source code
         uses: actions/checkout@v4

--- a/.github/workflows/npm-prepare-release.yml
+++ b/.github/workflows/npm-prepare-release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run npm-prepare-release
-        uses: Automattic/vip-actions/npm-prepare-release@v0.7.1
+        uses: Automattic/vip-actions/npm-prepare-release@7b98dcb98d652bf02037977b1b85abb971c345d0 # v0.7.1
         with:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           npm-version-type: ${{ inputs.npm-version-type }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: Automattic/vip-actions/npm-publish@v0.7.1
+      - uses: Automattic/vip-actions/npm-publish@7b98dcb98d652bf02037977b1b85abb971c345d0 # v0.7.1
         with:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     name: Stale
@@ -12,4 +15,4 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: Automattic/vip-actions/stale@trunk
+      - uses: Automattic/vip-actions/stale@a10bde8914496b7386d10fc5df9b4ffa2fd72ef1 # trunk


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to enhance security and stability by explicitly defining permissions and pinning action versions to specific commits. These changes ensure better control over access rights and improve the reproducibility of workflows.

### Security Improvements:
* Added explicit `permissions` configurations to the `.github/workflows/npm-prepare-release.yml` and `.github/workflows/stale.yml` files. This includes setting `contents: read` globally and defining job-specific permissions such as `contents: write` and `pull-requests: write` for the `prepare` job in `npm-prepare-release.yml`. [[1]](diffhunk://#diff-4f1ecd2c2b461ffe45b1c48e87996fdf15bd50cef3706d86a96654325d347c87R17-R32) [[2]](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894R7-R9)

### Stability Improvements:
* Updated the action versions in `.github/workflows/npm-prepare-release.yml`, `.github/workflows/npm-publish.yml`, and `.github/workflows/stale.yml` to use specific commit SHAs instead of branch names or tags. This ensures that the workflows use fixed versions of the actions (`npm-prepare-release`, `npm-publish`, and `stale`). [[1]](diffhunk://#diff-4f1ecd2c2b461ffe45b1c48e87996fdf15bd50cef3706d86a96654325d347c87R17-R32) [[2]](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L17-R17) [[3]](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894L15-R18)