### PR TITLE
fix(tests): handle EPIPE on process stdin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -118,6 +118,14 @@ async function replace( streamObj, replacements, binary = null ) {
 		 */
 		replaceProcess.stdout.on( 'data', resolve );
 
+		// EPIPE is expected when the process exits before consuming all stdin (e.g. non-zero exit).
+		// Swallow it here so the 'exit' handler can reject with the real error instead.
+		replaceProcess.stdin.on( 'error', ( err ) => {
+			if ( err.code !== 'EPIPE' ) {
+				reject( new Error( `Error writing to process stdin: ${ err.message }` ) );
+			}
+		} );
+
 		// let it flow;
 		streamObj.pipe( replaceProcess.stdin );
 	} );


### PR DESCRIPTION
When a child process exits before consuming all stdin (e.g., the non-zero-exit-code test script that exits immediately), Node.js emits `EPIPE` on `replaceProcess.stdin`. Without a handler, this becomes an unhandled `EventEmitter` 'error' event, causing Node.js to throw an uncaught exception that Jest catches and reports as the test failure.

Sometimes the exit event fires first (correct rejection), but sometimes the `EPIPE` unhandled exception fires first (wrong failure).

This PR adds an explicit error handler on `replaceProcess.stdin` that silently swallows `EPIPE` (expected/benign on early process exit) and rejects for any other unexpected stdin error.